### PR TITLE
use pngcairo as terminal

### DIFF
--- a/keys.sh
+++ b/keys.sh
@@ -24,7 +24,7 @@ cat > $PLOT << EOG
 EOD
 set xrange [0.99:1.01]
 set yrange [0.99:1.01]
-set terminal png transparent
+set terminal pngcairo transparent
 do for [i = $FROM:$TO] {
 	set output "key_".i.".png"
 	plot \$point using 1:1 with points lc i pt i


### PR DESCRIPTION
the machine generating the tests always falls back to using pngcairo due to a missing libharfbuzz. this can result in different pointtypes after the first 8 points as mentioned in `help pointtype`. also use pngcairo on machines that support libharfbuzz.