### PR TITLE
add favicon

### DIFF
--- a/Html.pm
+++ b/Html.pm
@@ -72,6 +72,7 @@ sub html_header {
 <head>
   <meta charset="UTF-8">
   <title>$title</title>
+  <link rel="icon" href="/favicon.svg">
   <style>
     th { text-align: left; white-space: nowrap; }
     th.desc { text-align: left; white-space: nowrap; }

--- a/favicon.ink.svg
+++ b/favicon.ink.svg
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   viewBox="0 0 16.933333 16.933333"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="puffy-testing.ink.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     units="px"
+     width="64px"
+     showguides="false"
+     inkscape:zoom="10.439364"
+     inkscape:cx="21.409349"
+     inkscape:cy="28.97686"
+     inkscape:window-width="1918"
+     inkscape:window-height="1078"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 12.236235,6.2749066 -3.918584,6.7871874 4.667204,2.694611 3.910981,-6.774019 z"
+       id="path23899"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="fill:#ff8080;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect23901"
+       width="0.94351572"
+       height="0.87612164"
+       x="14.196769"
+       y="0.0050690607"
+       transform="rotate(30)" />
+    <rect
+       style="fill:#ff8080;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect23903"
+       width="0.94351572"
+       height="0.87612164"
+       x="14.196769"
+       y="1.5155222"
+       transform="rotate(30)" />
+    <rect
+       style="fill:#ffff80;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect23905"
+       width="0.94351572"
+       height="0.87612164"
+       x="14.196769"
+       y="2.9407408"
+       transform="rotate(30)" />
+    <rect
+       style="fill:#8080ff;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect23907"
+       width="0.94351572"
+       height="0.87612164"
+       x="14.196769"
+       y="4.4081492"
+       transform="rotate(30)" />
+    <rect
+       style="fill:#80ff80;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect23909"
+       width="0.94351572"
+       height="0.87612164"
+       x="14.196769"
+       y="5.8411298"
+       transform="rotate(30)" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 13.856711,7.8390061 -1.467836,2.5423669 2.323149,1.34127"
+       id="path23911" />
+    <path
+       style="fill:none;stroke:#ff7e00;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 13.850974,8.368877 1.262607,2.186901"
+       id="path23913" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 11.988923,11.074109 -1.467836,2.542367 2.323149,1.34127"
+       id="path23915" />
+    <path
+       style="fill:none;stroke:#b513f7;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 10.885845,13.504631 c 1.198338,0.721652 2.041746,-1.264892 2.897065,-0.804782"
+       id="path23917"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:#dcbb43;fill-opacity:1;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 3.1737821,9.3236711 2.1460389,10.65608 3.561877,10.207742"
+       id="path26730"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:#dcbb43;fill-opacity:1;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 4.3431842,10.914469 -0.057662,1.39933 0.9875504,-0.917244"
+       id="path27059"
+       sodipodi:nodetypes="ccc" />
+    <circle
+       style="fill:#dcbb43;fill-opacity:1;stroke:#000000;stroke-width:0.230919;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1114"
+       cx="8.5451059"
+       cy="5.2697129"
+       r="4.7148857"
+       transform="rotate(15)" />
+    <path
+       style="fill:#dcbb43;fill-opacity:1;stroke:#000000;stroke-width:0.230919px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 2.6822702,5.4073662 1.2380532,4.2408624 C 1.6480161,6.0004972 1.479235,6.6443945 0.28243054,7.8072979 L 2.2844556,7.5275681"
+       id="path1405"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.230919px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 9.2083835,5.4545539 8.9374817,7.232814 11.577201,7.7409705 11.171283,5.833035 Z"
+       id="path1407"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#dcbb43;fill-opacity:1;stroke:#000000;stroke-width:0.230919px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9.3613769,10.36257 0.8299301,1.62973 1.225,-0.685055 -1.567644,-1.292607"
+       id="path1419" />
+    <path
+       id="path1991"
+       style="fill:#ece81a;fill-opacity:1;stroke:#000000;stroke-width:0.245952px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 12.15719,5.2033132 C 9.0268422,4.8267852 6.4096144,4.541016 3.3735404,4.1971526 L 1.5043108,3.9645928 M 11.14142,5.0769361 C 11.278706,3.477032 9.7181102,1.9963704 7.6193312,1.7352513 5.5203749,1.47411 3.6444348,2.5274256 3.3857244,4.1123644"
+       sodipodi:nodetypes="ccccsc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.230919px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 9.1798044,6.2875187 3.0369823,4.4721129"
+       id="path16635" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.230919px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 9.2212195,6.7681751 C 10.023048,6.0464919 10.251864,5.9002007 11.171283,5.833035 c 0.50445,0.6000694 0.371724,1.0313757 0.25121,1.6730104 z"
+       id="path17150"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 11.439903,8.2351615 C 10.467777,8.0219725 9.5280863,7.5199999 8.3557075,8.6418297 9.57302,8.7309775 10.04497,9.1533803 10.940882,9.5824158"
+       id="path27830"
+       sodipodi:nodetypes="ccc" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.230919;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path20224"
+       cx="12.534999"
+       cy="0.28693673"
+       rx="0.32703832"
+       ry="0.43215778"
+       transform="rotate(30.107025)" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path20680"
+       cx="11.849914"
+       cy="7.2612691"
+       rx="0.13382687"
+       ry="0.10706149" />
+    <ellipse
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.17602;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path20990"
+       cx="12.698706"
+       cy="0.33666781"
+       rx="0.1869663"
+       ry="0.21367577"
+       transform="rotate(30)" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 3.3857244,4.1123643 11.14142,5.0769362"
+       id="path25068" />
+    <path
+       style="fill:#dcbb43;fill-opacity:1;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 2.9119699,8.3960744 1.5946277,9.2574826 3.1635993,9.3282118"
+       id="path25480"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:#dcbb43;fill-opacity:1;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 3.561877,10.207742 3.2479204,11.495291 4.3431842,10.914469"
+       id="path25482"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:#dcbb43;fill-opacity:1;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 5.7039343,11.700692 0.1931038,1.006861 0.4643588,-0.934445"
+       id="path25484"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:#dcbb43;fill-opacity:1;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7.1040229,11.760473 0.2679654,1.053993 0.8463399,-1.161643"
+       id="path25486"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 3.0874861,7.4760662 2.6560187,8.1232671 3.3861943,7.9075336"
+       id="path27448" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 3.9383149,9.3843198 3.9217199,10.147686 4.4361619,9.5502688"
+       id="path27452" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 5.3714619,10.119425 v 0.763365 l 0.531037,-0.713581"
+       id="path27456" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.238581px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7.2013185,10.355834 0.1809301,0.911922 0.288255,-0.755042"
+       id="path27460" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 8.4697164,10.325557 9.1832971,10.989353 8.9841582,9.9604688"
+       id="path27462" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 3.6105618,5.9043218 2.8340062,5.8596602 3.389559,6.3802929"
+       id="path32492" />
+  </g>
+</svg>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,56 @@
+<svg width="64" height="64" version="1.1" viewBox="0 0 16.9 16.9" xmlns="http://www.w3.org/2000/svg">
+<g stroke="#000">
+<path d="m12.2 6.27-3.92 6.79 4.67 2.69 3.91-6.77z" fill="#fff" stroke-width=".265px"/>
+<g stroke-width=".265">
+<rect transform="rotate(30)" x="14.2" y=".00507" width=".944" height=".876" fill="#ff8080"/>
+<rect transform="rotate(30)" x="14.2" y="1.52" width=".944" height=".876" fill="#ff8080"/>
+<rect transform="rotate(30)" x="14.2" y="2.94" width=".944" height=".876" fill="#ffff80"/>
+<rect transform="rotate(30)" x="14.2" y="4.41" width=".944" height=".876" fill="#8080ff"/>
+<rect transform="rotate(30)" x="14.2" y="5.84" width=".944" height=".876" fill="#80ff80"/>
+</g>
+</g>
+<g fill="none" stroke-width=".265px">
+<path d="m13.9 7.84-1.47 2.54 2.32 1.34" stroke="#000"/>
+<path d="m13.9 8.37 1.26 2.19" stroke="#ff7e00"/>
+<path d="m12 11.1-1.47 2.54 2.32 1.34" stroke="#000"/>
+<path d="m10.9 13.5c1.2.722 2.04-1.26 2.9-.805" stroke="#b513f7"/>
+</g>
+<g fill="#dcbb43" stroke="#000">
+<path d="m3.17 9.32-1.03 1.33 1.42-.448" stroke-width=".265px"/>
+<path d="m4.34 10.9-.0577 1.4.988-.917" stroke-width=".265px"/>
+<circle transform="rotate(15)" cx="8.55" cy="5.27" r="4.71" stroke-width=".231"/>
+<path d="m2.68 5.41-1.44-1.17c.41 1.76.241 2.4-.956 3.57l2-.28" stroke-width=".231px"/>
+</g>
+<g stroke="#000">
+<path d="m9.21 5.45-.271 1.78 2.64.508-.406-1.91z" fill="none" stroke-width=".231px"/>
+<path d="m9.36 10.4.83 1.63 1.22-.685-1.57-1.29" fill="#dcbb43" stroke-width=".231px"/>
+<path d="m12.2 5.2c-3.13-.377-5.75-.662-8.78-1.01l-1.87-.233m9.64 1.11c.137-1.6-1.42-3.08-3.52-3.34-2.1-.261-3.97.792-4.23 2.38" fill="#ece81a" stroke-width=".246px"/>
+<path d="m9.18 6.29-6.14-1.82" fill="none" stroke-width=".231px"/>
+</g>
+<g>
+<g stroke="#000">
+<path d="m9.22 6.77c.802-.722 1.03-.868 1.95-.935.504.6.372 1.03.251 1.67z" fill="#fff" stroke-width=".231px"/>
+<path d="m11.4 8.24c-.972-.213-1.91-.715-3.08.407 1.22.0891 1.69.512 2.59.941" fill="#fff" stroke-width=".265px"/>
+<ellipse transform="rotate(30.1)" cx="12.5" cy=".287" rx=".327" ry=".432" stroke-width=".231"/>
+<ellipse cx="11.8" cy="7.26" rx=".134" ry=".107" stroke-width=".265"/>
+</g>
+<ellipse transform="rotate(30)" cx="12.7" cy=".337" rx=".187" ry=".214" fill="#fff"/>
+</g>
+<path d="m3.39 4.11 7.76.965" fill="none" stroke="#000" stroke-width=".265px"/>
+<g fill="#dcbb43" stroke="#000" stroke-width=".265px">
+<path d="m2.91 8.4-1.32.861 1.57.0707"/>
+<path d="m3.56 10.2-.314 1.29 1.1-.581"/>
+<path d="m5.7 11.7.193 1.01.464-.934"/>
+<path d="m7.1 11.8.268 1.05.846-1.16"/>
+</g>
+<g fill="none" stroke="#000">
+<g stroke-width=".265px">
+<path d="m3.09 7.48-.431.647.73-.216"/>
+<path d="m3.94 9.38-.0166.763.514-.597"/>
+<path d="m5.37 10.1v.763l.531-.714"/>
+</g>
+<path d="m7.2 10.4.181.912.288-.755" stroke-width=".239px"/>
+<path d="m8.47 10.3.714.664-.199-1.03" stroke-width=".265px"/>
+<path d="m3.61 5.9-.777-.0447.556.521" stroke-width=".265px"/>
+</g>
+</svg>


### PR DESCRIPTION
The following scripts use their own <head> instead, should they also set the favicon?
```
cvslog.pl:  <title>OpenBSD CVS Log</title>
gnuplot.pl:  <title>OpenBSD Perform $htmltitle Results</title>
setup-html.pl:    print $html "  <title>OpenBSD CVS Build</title>\n";
setup-html.pl:    print $html "  <title>OpenBSD Machine Reboot</title>\n";
```

Currently the favicon is an svg which is quite big for something that results in a 16x16px icon (in my browser), currently the optimized svg is 2.9KB, reducing the digits could lead to something of size 2.3KB that looks very similar on a 16x16 canvas. A png of size 16x16 could be <800B, an ico file 1.1KB.

The current method of using an svg doesn't work on safari and iOS, on the internet it is recommended to set 5 different icons of various sizes and file types. [1](https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs) [2](https://medium.com/swlh/are-you-using-svg-favicons-yet-a-guide-for-modern-browsers-836a6aace3df)
Adding a build step or 5 different binary files could work but I think not doing that would be best.

`favicon.ink.svg` is the original inkscape svg including editor metadata.

This doesn't change the index.html page, that one is not in this repo, right?

What about a license? Do I need to state it somewhere? I am open to suggestions.