### PR TITLE
Add rust-openssl regress to libssl tests

### DIFF
--- a/pkg-ot1.list
+++ b/pkg-ot1.list
@@ -30,6 +30,8 @@ posixtestsuite
 py3-tlsfuzzer
 rsync--
 rsyslog
+rust
+rust-openssl-tests
 scapy
 sudo--
 sysclean

--- a/pkg-ot10.list
+++ b/pkg-ot10.list
@@ -31,6 +31,8 @@ py3-tlsfuzzer
 raspberrypi-firmware
 rsync--
 rsyslog
+rust
+rust-openssl-tests
 scapy
 sudo--
 sysclean

--- a/pkg-ot11.list
+++ b/pkg-ot11.list
@@ -31,6 +31,8 @@ py3-tlsfuzzer
 raspberrypi-firmware
 rsync--
 rsyslog
+rust
+rust-openssl-tests
 scapy
 sudo--
 sysclean

--- a/pkg-ot2.list
+++ b/pkg-ot2.list
@@ -30,6 +30,8 @@ posixtestsuite
 py3-tlsfuzzer
 rsync--
 rsyslog
+rust
+rust-openssl-tests
 scapy
 sudo--
 sysclean

--- a/pkg-ot21.list
+++ b/pkg-ot21.list
@@ -23,6 +23,8 @@ p5-NetPacket
 p5-YAML
 p5-ldap
 rsync--
+rust
+rust-openssl-tests
 scapy
 sudo--
 sysclean

--- a/pkg-ot27.list
+++ b/pkg-ot27.list
@@ -29,6 +29,8 @@ posixtestsuite
 py3-tlsfuzzer
 rsync--
 rsyslog
+rust
+rust-openssl-tests
 scapy
 sudo--
 sysclean

--- a/pkg-ot5.list
+++ b/pkg-ot5.list
@@ -30,6 +30,8 @@ posixtestsuite
 py3-tlsfuzzer
 rsync--
 rsyslog
+rust
+rust-openssl-tests
 scapy
 sudo--
 sysclean

--- a/pkg-ot6.list
+++ b/pkg-ot6.list
@@ -30,6 +30,8 @@ posixtestsuite
 py3-tlsfuzzer
 rsync--
 rsyslog
+rust
+rust-openssl-tests
 scapy
 sudo--
 sysclean

--- a/test.list
+++ b/test.list
@@ -169,6 +169,7 @@ lib/libssl/pqueue
 lib/libssl/quic
 lib/libssl/record
 lib/libssl/record_layer
+lib/libssl/rust-openssl
 lib/libssl/server
 lib/libssl/ssl
 lib/libssl/tls


### PR DESCRIPTION
This test needs the rust and rust-openssl-tests packages to run.