### PR TITLE
Add `lib/libcrypto/aes` to test list

### DIFF
--- a/test.list
+++ b/test.list
@@ -81,6 +81,7 @@ lib/libc/vis
 lib/libc/wprintf
 lib/libcrypto/CA
 lib/libcrypto/aead
+lib/libcrypto/aes
 lib/libcrypto/aeswrap
 lib/libcrypto/asn1
 lib/libcrypto/base64


### PR DESCRIPTION
Add the `lib/libcrypto/aes` directory to the test list