### PR TITLE
Switch from OpenSSL 1.0.2 to OpenSSL 3.0

### DIFF
--- a/pkg-ot1.list
+++ b/pkg-ot1.list
@@ -9,8 +9,8 @@ gsed
 iperf3
 net-snmp
 openldap-client--
-openssl%1.0.2
 openssl%1.1
+openssl%3.0
 openssl-ruby-tests
 os-test
 p5-AnyEvent

--- a/pkg-ot10.list
+++ b/pkg-ot10.list
@@ -9,8 +9,8 @@ gsed
 iperf3
 net-snmp
 openldap-client--
-openssl%1.0.2
 openssl%1.1
+openssl%3.0
 openssl-ruby-tests
 os-test
 p5-AnyEvent

--- a/pkg-ot11.list
+++ b/pkg-ot11.list
@@ -9,8 +9,8 @@ gsed
 iperf3
 net-snmp
 openldap-client--
-openssl%1.0.2
 openssl%1.1
+openssl%3.0
 openssl-ruby-tests
 os-test
 p5-AnyEvent

--- a/pkg-ot2.list
+++ b/pkg-ot2.list
@@ -9,8 +9,8 @@ gsed
 iperf3
 net-snmp
 openldap-client--
-openssl%1.0.2
 openssl%1.1
+openssl%3.0
 openssl-ruby-tests
 os-test
 p5-AnyEvent

--- a/pkg-ot21.list
+++ b/pkg-ot21.list
@@ -6,8 +6,8 @@ gsed
 iperf3
 net-snmp
 openldap-client--
-openssl%1.0.2
 openssl%1.1
+openssl%3.0
 openssl-ruby-tests
 p5-AnyEvent
 p5-BSD-Resource

--- a/pkg-ot26.list
+++ b/pkg-ot26.list
@@ -9,8 +9,8 @@ gsed
 iperf3
 net-snmp
 openldap-client--
-openssl%1.0.2
 openssl%1.1
+openssl%3.0
 openssl-ruby-tests
 os-test
 p5-AnyEvent

--- a/pkg-ot27.list
+++ b/pkg-ot27.list
@@ -8,8 +8,8 @@ gsed
 iperf3
 net-snmp
 openldap-client--
-openssl%1.0.2
 openssl%1.1
+openssl%3.0
 openssl-ruby-tests
 os-test
 p5-AnyEvent

--- a/pkg-ot29.list
+++ b/pkg-ot29.list
@@ -44,8 +44,8 @@ npth
 open62541
 openldap-client--
 openldap-server--%openldap
-openssl%1.0.2
 openssl%1.1
+openssl%3.0
 openssl-ruby-tests
 os-test
 p11-kit

--- a/pkg-ot5.list
+++ b/pkg-ot5.list
@@ -9,8 +9,8 @@ gsed
 iperf3
 net-snmp
 openldap-client--
-openssl%1.0.2
 openssl%1.1
+openssl%3.0
 openssl-ruby-tests
 os-test
 p5-AnyEvent

--- a/pkg-ot6.list
+++ b/pkg-ot6.list
@@ -9,8 +9,8 @@ gsed
 iperf3
 net-snmp
 openldap-client--
-openssl%1.0.2
 openssl%1.1
+openssl%3.0
 openssl-ruby-tests
 os-test
 p5-AnyEvent

--- a/pkg-ot7.list
+++ b/pkg-ot7.list
@@ -10,8 +10,8 @@ gsed
 iperf3
 net-snmp
 openldap-client--
-openssl%1.0.2
 openssl%1.1
+openssl%3.0
 openssl-ruby-tests
 os-test
 p5-AnyEvent

--- a/pkg-ot8.list
+++ b/pkg-ot8.list
@@ -9,8 +9,8 @@ gsed
 iperf3
 net-snmp
 openldap-client--
-openssl%1.0.2
 openssl%1.1
+openssl%3.0
 openssl-ruby-tests
 os-test
 p5-AnyEvent


### PR DESCRIPTION
OpenSSL 1.0.2 will be removed from the ports tree since it is full of known security issues and no longer receives security updates. interop tests have been updated to pick up OpenSSL 3.0 if it's present.