### PR TITLE
use warn and exit 0 instead of die.

### DIFF
--- a/netlink.pl
+++ b/netlink.pl
@@ -220,12 +220,16 @@ mysystem('ssh', $lnx_r_ssh, 'ip', '-6', 'neigh', 'flush', 'all', 'dev',
 # configure given interface type
 if ($pseudodev eq 'bridge' || $pseudodev eq 'none') {
     if ($ipv4) {
-	mysystem('ifconfig', $obsd_l_if, 'inet', "${obsd_l_addr}/24") and die "command failed";
-	mysystem('ifconfig', $obsd_r_if, 'inet', "${obsd_r_addr}/24") and die "command failed";
+	mysystem('ifconfig', $obsd_l_if, 'inet', "${obsd_l_addr}/24")
+	    and do { warn "command failed: $?"; exit 0; };
+	mysystem('ifconfig', $obsd_r_if, 'inet', "${obsd_r_addr}/24")
+	    and do { warn "command failed: $?"; exit 0; };
     }
     if ($ipv6) {
-	mysystem('ifconfig', $obsd_l_if, 'inet6', $obsd_l_addr6) and die "command failed";
-	mysystem('ifconfig', $obsd_r_if, 'inet6', $obsd_r_addr6) and die "command failed";
+	mysystem('ifconfig', $obsd_l_if, 'inet6', $obsd_l_addr6)
+	    and do { warn "command failed: $?"; exit 0; };
+	mysystem('ifconfig', $obsd_r_if, 'inet6', $obsd_r_addr6)
+	    and do { warn "command failed: $?"; exit 0; };
     }
 }
 


### PR DESCRIPTION
This case is reached in case the interface does not exist.