### PR TITLE
The ENGINE test will be removed

### DIFF
--- a/test.list
+++ b/test.list
@@ -102,7 +102,6 @@ lib/libcrypto/dsa
 lib/libcrypto/ec
 lib/libcrypto/ecdh
 lib/libcrypto/ecdsa
-lib/libcrypto/engine
 lib/libcrypto/evp
 lib/libcrypto/free
 lib/libcrypto/gcm128


### PR DESCRIPTION
This only prints that ENGINE was disabled nowadays, so it is useless.