### PR TITLE
whirlpool was removed

### DIFF
--- a/test.list
+++ b/test.list
@@ -128,7 +128,6 @@ lib/libcrypto/sm3
 lib/libcrypto/sm4
 lib/libcrypto/symbols
 lib/libcrypto/utf8
-lib/libcrypto/whirlpool
 lib/libcrypto/wycheproof
 lib/libcrypto/x509
 lib/libedit


### PR DESCRIPTION
This should be the only adjustment needed for today's bump. The rust-openssl test is likely to fail unless you have 20240830p0, everything else is expected to pass.